### PR TITLE
Remove 3.9 from test workflow and add 3.13.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
As of Beam 2.70, we supported python 3.10 - 3.13.

- https://github.com/apache/beam/pull/36665
- https://github.com/apache/beam/pull/35056